### PR TITLE
Adding more try to check server alive and adding black to requirements

### DIFF
--- a/http_server_mock.py
+++ b/http_server_mock.py
@@ -41,7 +41,7 @@ class _RunInBackground(object):
 
     def __enter__(self):
         is_alive = False
-        for _ in range(5):
+        for _ in range(40):
             try:
                 r = requests.put(
                     "http://" + self.host + ":" + str(self.port) + self.is_alive_route

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest==5.0.0
 pytest-black==0.3.7
 pytest-cov==2.7.1
 requests==2.20.0
+black==19.10b0


### PR DESCRIPTION
Increase the number of try's from 5 to 40, this will give at least 2 seconds to check if server really is alive