### PR TITLE
Updated readme with example + note to avoid 'server not alive' exception for certain ports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,15 +25,17 @@ Using http-server-mock is similar to implement any Flask application.
 .. code:: python
 
     from http_server_mock import HttpServerMock
-    import requests
+    import requests, http
     app = HttpServerMock(__name__)
 
     @app.route("/", methods=["GET"])
     def index():
-        return "Hello world"
+        return "Hello world", http.HTTPStatus.OK
 
-    with app.run("localhost", 5000):
-        r = requests.get("http://localhost:5000/")
+    # you may get 'Server isn't alive' Exception with certain ports on macOS
+    # https://stackoverflow.com/questions/72795799/how-to-solve-403-error-with-flask-in-python
+    with app.run("localhost", 9000):
+        r = requests.get("http://localhost:9000/")
         # r.status_code == 200
         # r.text == "Hello world"
 


### PR DESCRIPTION
o- example showing how to also return status code along with mock response. (as a newbie to python, had to dig into the code to figure this out. might be useful to others)

o- putting a note on how to avoid 'Server is not alive' exception for certain ports on macOS. port 5000 gave http 403 error on is_alive route and tests started failing/ sample code failed too. 

thank you.